### PR TITLE
Fix assumed async methods

### DIFF
--- a/People/People/PersonRepository.cs
+++ b/People/People/PersonRepository.cs
@@ -24,7 +24,7 @@ namespace People
             _dbPath = dbPath;                        
         }
 
-        public void AddNewPerson(string name)
+        public async Task AddNewPerson(string name)
         {            
             int result = 0;
             try
@@ -47,12 +47,11 @@ namespace People
 
         }
 
-        public <List<Person> GetAllPeople()
+        public async Task<List<Person>> GetAllPeople()
         {
-            // TODO: Init then retrieve a list of Person objects from the database into a list
             try
             {
-                
+                // TODO: Init then retrieve a list of Person objects from the database into a list
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
The exercise uses the `GetAllPeople` and `AddNewPerson` methods via an async call:

```csharp
await App.PersonRepo.AddNewPerson(newPerson.Text);

// ...

List<Person> people = await App.PersonRepo.GetAllPeople();
```

But the methods defined in the exercise files are not correctly labelled as `async Task`.

I've modified the method definitions to prevent this confusion and potential tripping point for those not familiar with async methods.

Additionally I've moved one of the `TODO` comments as it made more sense inside the `try` than before it.